### PR TITLE
adding nowarp #28

### DIFF
--- a/public/assets/scrpits/header-script.js
+++ b/public/assets/scrpits/header-script.js
@@ -1,13 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const toggle = document.querySelector('.menu-toggle');
-    const menu = document.querySelector('.menu');
-    const close = document.querySelector('.menu-close');
+  const toggle = document.querySelector('.menu-toggle');
+  const menu = document.querySelector('.menu');
 
-    toggle.addEventListener('click', () => {
-      menu.classList.add('open');
-    });
-
-    close.addEventListener('click', () => {
-      menu.classList.remove('open');
-    });
+  toggle.addEventListener('click', (event) => {
+    event.stopPropagation(); 
+    menu.classList.toggle('open');
   });
+
+  // Close menu when clicking outside
+  document.addEventListener('click', (event) => {
+    const insideMenu = menu.contains(event.target);
+    const ClickOnToggle = toggle.contains(event.target);
+
+    if (!insideMenu && !ClickOnToggle) {
+      menu.classList.remove('open');
+    }
+  });
+});

--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -124,7 +124,8 @@ header {
   .inline {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.2rem;
+    white-space: nowrap;
     a, h1{
       text-decoration: none;
     }
@@ -137,7 +138,6 @@ header {
     margin-bottom: 3em;
     padding: 1rem;
     ul{
-      gap: 1em; 
       border: 2em;
       list-style: none;
       


### PR DESCRIPTION
What does this change?
Resolves issue #28
This change addresses a layout issue on mobile devices where elements were not aligning inline as per the Figma design. Feedback from Regina indicated the misalignment, which was resolved by adjusting the CSS, including adding white-space: nowrap; to the necessary elements.

This update ensures consistency between the design and implementation across screen sizes, improving the responsive behavior of the page.

Live site preview

How Has This Been Tested?

- [x]  Responsive Design test
- [x]  Device test (mobile and tablet)
- [x]  User test

<hr>

Images
Before:

![exer-foult](https://github.com/user-attachments/assets/9aa94743-e349-4cd1-b1c3-687c14edb36e)

After:
![last-exe](https://github.com/user-attachments/assets/8175027b-f311-4748-bdc5-873556a936ff)

<hr>

How to review

Open the Drop & Heal Exercise page on a mobile device.

Check that the items are not aligned inline.

On this branch:

Open the same page on mobile.

Check that the layout now matches the Figma design, with elements correctly aligned inline.
